### PR TITLE
cluster: support request/response within a cluster

### DIFF
--- a/cluster.js
+++ b/cluster.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/cluster');

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-exports.server = require('server');
-exports.client = require('client');
+exports.client = require('./client');
+exports.cluster = require('./cluster');
+exports.server = require('./server');

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,12 +10,12 @@ var toPipe = require('./pipe').toPipe;
 function request(addr, request, callback) {
   addr = toPipe(addr);
 
-  debug('connect to: %s', addr);
+  debug('connect to: %s send:', addr, request);
 
   var socket = net.connect(addr);
   var ch = channel.fromSocket(socket);
 
-  ch.send(request); // XXX do I need to wait for connection event?
+  ch.send(request);
 
   ch.once('message', function(response) {
     if (callback) {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -1,0 +1,220 @@
+// control channel cluster
+//
+// cluster message format is:
+//
+// # cmd
+//
+// one of:
+//
+// -'strong-control-channel:request'
+// -'strong-control-channel:response'
+//
+// # data
+//
+// request or response message
+//
+// By convention, data has a format, it is
+//
+// - cmd: identification of request
+// - error: if request failed, this will be the reason
+//
+// # seqno
+//
+// sequence number, for correlating requests and responses
+
+var REQ = 'strong-control-channel:request';
+var RSP = 'strong-control-channel:response';
+
+var assert = require('assert');
+var channel = require('./channel');
+var cluster = require('cluster');
+var debug = require('./debug')('cluster-' + (cluster.worker ?
+                              cluster.worker.id : 'm'));
+var events = require('events');
+var util = require('util');
+
+function Server(onRequest) {
+  assert(onRequest);
+
+  var self = this;
+
+  self.onRequest = onRequest;
+  self.requests = {};
+  self.seqno = 0;
+
+  self.on('message', function(message, worker) {
+    var seqno = message.seqno;
+
+    if (message.cmd === REQ) {
+      var request = message.data;
+
+      debug('channel request #%d %j', message.seqno, request);
+
+      if (!self.onRequest) {
+        self._send(worker, {
+          cmd: RSP, seqno: seqno, data: {error: 'unsupported'}
+        });
+        return;
+      }
+
+      self.onRequest(request, function(response) {
+        debug('channel response #%d %j', message.seqno, response);
+
+        self._send(worker, {cmd: RSP, seqno: seqno, data: response});
+      });
+    }
+
+    if (message.cmd === RSP) {
+      var response = message.data;
+
+      debug('channel response #%d %j', message.seqno, message);
+
+      var callback = self.requests[message.seqno];
+
+      delete self.requests[message.seqno];
+
+      if (callback === undefined) {
+        debug('channel response seqno %d unknown!', message.seqno);
+        return;
+      }
+
+      callback(message.data);
+    }
+  });
+
+  self._attach();
+}
+
+util.inherits(Server, events.EventEmitter);
+
+// Ensure all cluster messages are emitted on self with the worker object
+// that the response should be sent to.
+//
+// This will look like:
+//
+//   self.emit('message', message, worker);
+//
+// In a worker, there is only one worker, but in a master, we have to listen for
+// the message event on each newly forked worker :-(
+Server.prototype._attach = function _attach() {
+  var self = this;
+
+  // In a worker, messages come only from master.
+  if (cluster.isWorker) {
+    cluster.worker.on('message', function(message) {
+      self.emit('message', message, cluster.worker);
+    });
+
+    return;
+  }
+
+  // In a master, we need to listen for messages on all workers as they are
+  // forked, and tell the message server which worker the message came from, as
+  // well as any workers that were already forked.
+  for (var id in cluster.workers) {
+    listen(cluster.workers[id]);
+  }
+
+  cluster.on('fork', listen);
+
+  function listen(worker) {
+    worker.on('message', function(message) {
+      self.emit('message', message, worker);
+    });
+  }
+};
+
+Server.prototype._send = function _send(worker, message) {
+  try {
+    worker.send(message);
+  } catch(er) {
+    // can happen if other side disconnected since sending message,
+    // there is nothing we can do if the sender died before receiving the
+    // response.
+    debug('cluster send failed: %s', er);
+  }
+};
+
+function Self(server, callback) {
+  var self = this;
+  this.callback;
+  this.send = function(message) {
+    debug('self-send %j', message);
+
+    process.nextTick(function() {
+      server.emit('message', message, self);
+    });
+  }
+}
+
+// Send a single request, callbacks with err, response
+//
+// dst is either a cluster worker ID, or a process ID. In the master, it
+// can be it's own process ID, or the (never valid in node) worker ID of 0,
+// used to mean 'master'
+Server.prototype.request = function request(dst, request, callback) {
+  debug('dst %s request %j', dst, request);
+
+  if (cluster.isWorker) {
+    if (dst !== 0)
+      return;
+
+    var worker = cluster.worker;
+  } else {
+    function isMatch(w) {
+      if (w.id === dst || w.process.pid === dst) {
+        return w;
+      }
+    }
+
+    if (dst === 0 || dst === process.pid) {
+      // Send to self,
+      // fake this out with a wrapper that does the right thing for the request
+      // and response send
+      worker = new Self(this, callback);
+    } else {
+      for (var id in cluster.workers) {
+        worker = isMatch(cluster.workers[id]);
+        if (worker)
+          break;
+      }
+    }
+    if (!worker)
+      return;
+  }
+
+  var seqno = this.seqno++;
+  this.requests[seqno] = callback;
+  this._send(worker, {
+    cmd: REQ,
+    data: request,
+    seqno: seqno
+  });
+
+  return this;
+}
+
+// On request, callback will be called with request and callback.
+//
+// callback should be called with response.
+//
+// Only one can be created (because there is only one instance of cluster module
+// to attach to).
+function attach(onRequest) {
+  assert(!cluster._strongControlChannel);
+
+  debug('attaching to cluster in pid %d', process.pid);
+
+  cluster._strongControlChannel = new Server(onRequest);
+
+  return cluster._strongControlChannel;
+}
+
+// usage:
+//
+// require('strong-control-channel/cluster')(function(request, callback) {
+//   callback({/* ...some response... */});
+// });
+//
+module.exports = attach;
+module.exports.attach = attach;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,11 @@
     "email": "sam@strongloop.com"
   },
   "dependencies": {
-    "debug": "^1.0.3",
+    "debug": "^1.0.4",
     "newline-json": "^0.1.1"
   },
   "devDependencies": {
+    "async": "^0.9.0",
     "tap": "git://github.com/strongloop/node-tap#production"
   },
   "engines": {

--- a/test/test-cluster.js
+++ b/test/test-cluster.js
@@ -1,0 +1,90 @@
+var assert = require('assert');
+var async = require('async');
+var cluster = require('cluster');
+
+cluster.setupMaster({exec: require.resolve('./worker')});
+
+// To ensure that we listen for messages on pre-existing workers, as well as any
+// workers forked after we attach to cluster, we fork one, attach, then fork
+// another.
+var jun = cluster.fork();
+var ch = require('../').cluster(onRequest);
+var leo = cluster.fork();
+
+var master = { // fake Worker for master, to compare against in test()
+  id: 0,
+  process: {
+    pid: process.pid
+  }
+};
+
+var ECHO = {cmd: 'echo'};
+var HELO = {cmd: 'hello'};
+var NULL = {};
+
+var tests = [
+  test(jun, jun.id, ECHO),
+  test(leo, leo.id, ECHO),
+  test(jun, jun.process.pid, ECHO),
+  test(leo, leo.process.pid, ECHO),
+  test(leo, leo.id, NULL, 'unsupported'),
+  test(jun, jun.process.pid, NULL, 'unsupported'),
+  test(master, 0, HELO),
+  test(master, process.pid, HELO),
+  test(master, 0, NULL, 'unsupported'),
+  test(master, process.pid, NULL, 'unsupported'),
+];
+
+function test(worker, dst, request, error) {
+  return function(done) {
+    ch.request(dst, request, function(response) {
+      console.log('dst %d req %j rsp %j should error? %s',
+        dst, request, response, error);
+
+      assert.equal(request.cmd, response.cmd);
+
+      if (worker) {
+        assert.equal(worker.id, response.wid);
+        assert.equal(worker.process.pid, response.pid);
+      }
+      if (error) {
+        assert.equal(error, response.error);
+      }
+      return done();
+    });
+  };
+}
+
+async.parallel(tests, function(err) {
+  assert.ifError(err);
+  cluster.disconnect();
+  ok = true;
+});
+
+function onRequest(request, callback) {
+  console.log('master recv request %j', request);
+
+  request.wid = 0;
+  request.pid = process.pid;
+
+  if (request.cmd === HELO.cmd) {
+    request.helo = 'from master';
+  } else {
+    request.error = 'unsupported';
+  }
+
+  console.log('master send response %j', request);
+
+  return callback(request);
+}
+
+// Ensure we are exiting because tests are OK.
+
+var ok;
+
+process.on('exit', function(code) {
+  if (code === 0) {
+    assert(ok);
+    console.log('PASS');
+  }
+});

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+var ch = require('../').cluster(onRequest);
+var cluster = require('cluster');
+
+function onRequest(request, callback) {
+  console.log('worker %d recv request %j', cluster.worker.id, request);
+
+  var _callback = callback;
+
+  callback = function(message) {
+    console.log('worker %d send response %j', cluster.worker.id, message);
+    return _callback(message);
+  };
+
+  request.pid = process.pid;
+  request.wid = cluster.worker.id;
+
+  if (request.cmd === 'delay') {
+    setTimeout(function() {
+      request.message = 'delayed!';
+      callback(request);
+    }, request.delay);
+    return;
+  }
+  if (request.cmd === 'echo') {
+    request.message = 'echoed!';
+    callback(request);
+    return;
+  }
+  request.error = 'unsupported';
+  callback(request);
+}
+
+console.log('worker id %d pid %d', cluster.worker.id, process.pid);
+
+process.nextTick(function() {
+  console.log('worker sends hello');
+
+  ch.request(0, {cmd: 'hello'}, function(response) {
+    console.log('worker recv hello => %j', response);
+    assert.equal(response.cmd, 'hello');
+  });
+
+  console.log('worker sends no-such-cmd');
+
+  ch.request(0, {cmd: 'no-such-cmd'}, function(response) {
+    console.log('worker recv no-such-cmd => %j', response);
+    assert.equal(response.error, 'unsupported');
+  });
+});


### PR DESCRIPTION
/to @kraman 

Destined for strong-supervisor, so it can ask its workers to start and stop profiling.
