### PR TITLE
Allow Client requests to provide a callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,8 +28,8 @@ function Client(addr, onResponse, onNotification, onError) {
   }
 }
 
-Client.prototype.request = function (req) {
-  this._protocol.request(this._ch, req, this._onResponse);
+Client.prototype.request = function (req, callback) {
+  this._protocol.request(this._ch, req, callback || this._onResponse);
 };
 
 Client.prototype.close = function () {


### PR DESCRIPTION
Required for PM's Docker driver to be able to use a single connection but still be able to associate responses with their requests.