### PR TITLE
Call response callbacks asynchronously

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -108,7 +108,7 @@ Protocol.prototype.process = function process(message, worker) {
       return;
     }
 
-    callback(message.data);
+    setImmediate(callback, message.data);
   }
 
   if (message.cmd === NOT) {
@@ -118,7 +118,7 @@ Protocol.prototype.process = function process(message, worker) {
       message.seqno,
       debug.json(notification));
     if (self.onNotification) {
-      self.onNotification(notification);
+      setImmediate(self.onNotification.bind(self), notification);
     }
   }
 };


### PR DESCRIPTION
Otherwise an exception in the response handler is thrown up to the
channel's receive message handler and turned into a socket or channel
error event with no stack trace.

@sam-github this has been driving me nuts, getting useless errors like:

strong-pm:docker:container onError:  +1ms [Error: Cannot set property 'appName' of undefined in "{\"cmd\":\"strong-control-channel:response\",\"seqno\":0,\"data\":{\"master\":{\"pid\":1,\"setSize\":8,\"startTime\":1431642523935,\"pst\":1431642523935},\"workers\":[{\"id\":\"1\",\"pid\":6,\"uptime\":38,\"startTime\":1431642524092},{\"id\":\"2\",\"pid\":8,\"uptime\":2,\"startTime\":1431642524128}],\"appName\":\"loopback-example-app\",\"agentVersion\":\"1.5.1\"}}\n"] undefined