### PR TITLE
Api simplifications for central/executor

### DIFF
--- a/lib/ws-channel.js
+++ b/lib/ws-channel.js
@@ -12,17 +12,14 @@ var RSP = 'strong-control-channel:response';
 var NOT = 'strong-control-channel:notification';
 
 
-function WebsocketChannel(onRequest, onNotification) {
+function WebsocketChannel(onRequest) {
   assert(onRequest);
-  assert(onNotification);
 
   this._onRequest = onRequest;
-  this._onNotification = onNotification;
-
-  this._websocket = null;
-  this._socket = null;
 
   // Initialize to empty.
+  this._websocket = null;
+  this._socket = null;
   this._error = null;
   this._sendQueue = [];
   this._uri = null;
@@ -35,11 +32,18 @@ function WebsocketChannel(onRequest, onNotification) {
 
 util.inherits(WebsocketChannel, events.EventEmitter);
 
+WebsocketChannel.prototype._onNotification = function(message) {
+  this._onRequest(message, nullCallback);
+};
+
+function nullCallback() {
+}
 
 WebsocketChannel.prototype.connect = function(uri, token) {
+  token = token || url.parse(uri).auth;
   assert(!this._websocket);
   assert(uri);
-  assert(token);
+  assert(token, 'token required');
   this._uri = uri;
   this._token = token;
 
@@ -247,13 +251,18 @@ WebsocketChannel.prototype._handleError = function(err) {
 
 
 // Used by WebsocketRouter#createChannel()
-WebsocketChannel.create = function(onRequest, onNotification) {
-  return new WebsocketChannel(onRequest, onNotification);
+WebsocketChannel.create = function(onRequest) {
+  return new WebsocketChannel(onRequest);
 };
 
 
-// Use to connect to a `ws://host:port/path`, token must be known from
-// the server (communicated out of band).
-WebsocketChannel.connect = function(onRequest, onNotification, uri, token) {
-  return new WebsocketChannel(onRequest, onNotification).connect(uri, token);
+// Use to connect to a serveer, token/uri must be known from the server
+// (communicated out of band).
+//
+// onRequest, receive requests/notifications from server
+// uri, ws://[token@]host:port/path
+// token, used to connect to server, overrides the token in the uri, mandatory
+//   if the uri does not have a token
+WebsocketChannel.connect = function(onRequest, uri) {
+  return new WebsocketChannel(onRequest).connect(uri);
 };

--- a/lib/ws-router.js
+++ b/lib/ws-router.js
@@ -1,6 +1,10 @@
+'use strict';
+
 module.exports = WebsocketRouter;
 
 var WebsocketChannel = require('./ws-channel');
+var assert = require('assert');
+var debug = require('debug')('strong-control-channel:ws-router');
 
 
 // app, an express instance
@@ -18,9 +22,11 @@ function WebsocketRouter(app, path) {
 // Create a channel for a specific client, so that it can connect to it's
 // specific channel.  The client will need to be informed of the channel token
 // out-of-band in order to connect.
-WebsocketRouter.prototype.createChannel = function(onRequest, onNotification) {
-  var channel = WebsocketChannel.create(onRequest, onNotification);
-  var token = channel.createToken();
+WebsocketRouter.prototype.createChannel = function(onRequest, token) {
+  var channel = WebsocketChannel.create(onRequest);
+  token = token || channel.createToken();
+
+  assert(!this._channels[token], 'token is not unique: ' + token);
 
   this._channels[token] = channel;
 
@@ -32,6 +38,8 @@ WebsocketRouter.prototype.handleSocket = function(websocket) {
   var headers = websocket.upgradeReq.headers;
   var token = headers['x-mesh-token'];
   var channel = this._channels[token];
+
+  debug('receive websocket: token %j acceptable? %j', token, !!channel);
 
   if (!channel)
     return websocket.close();

--- a/test/test-ws.js
+++ b/test/test-ws.js
@@ -1,13 +1,17 @@
+'use strict';
+
 var assert = require('assert');
 var express = require('express');
 var expressWs = require('express-ws');
 var extend = require('util')._extend;
 var http = require('http');
+var url = require('url');
 var WebsocketChannel = require('../ws-channel');
 var WebsocketRouter = require('../ws-router');
 
-var ctlUri = 'ws://127.0.0.1:9999/channel';
 var isParent = process.argv[2] !== 'child';
+var debug = require('debug')('strong-control-channel:test:' + (isParent ?
+  'parent' : 'child'));
 
 var gotRequest = 0;
 var gotResponse = 0;
@@ -31,33 +35,53 @@ if (isParent) {
 
   // Create http + express server.
   var app = express();
-  var server = http.createServer(app).listen(9999);
+  var server = http.createServer(app).listen(0);
   expressWs(app, server);
+
+  server.on('error', function(err) {
+    debug('err: %j', err);
+    assert.ifError(err);
+  });
 
   // Create a websocket handler.
   var router = new WebsocketRouter(app, 'channel');
-  channel = router.createChannel(onServerRequest, onServerNotification);
+  channel = router.createChannel(onServerRequest);
 
   function onServerRequest(message, callback) {
-    console.log('server got', message);
-    assert(message.cmd === 'serverRequest');
-    gotRequest++;
-    callback({cmd: 'serverResponse'});
-  }
+    debug('server got', message);
+    if (message.cmd === 'serverRequest') {
+      assert(message.cmd === 'serverRequest');
+      gotRequest++;
+      callback({cmd: 'serverResponse'});
+      return;
+    }
 
-  function onServerNotification(message) {
-    console.log('server got', message);
     assert(message.cmd === 'serverNotification');
     gotNotification++;
   }
 
-  var env = extend({MESH_TOKEN: channel.getToken()}, process.env_);
-  require('child_process').fork(process.argv[1],
-                                ['child'],
-                                {stdio: 'inherit', env: env});
+  server.once('listening', function() {
+    var uri = url.format({
+      protocol: 'ws',
+      slashes: true,
+      auth: channel.getToken(),
+      hostname: '127.0.0.1',
+      port: this.address().port,
+      pathname: 'channel',
+    });
+    debug('mesh uri: %s', uri);
+    var env = extend({MESH_URI: uri}, process.env);
+    require('child_process').fork(process.argv[1], ['child'], {
+      stdio: 'inherit',
+      env: env
+    }).on('exit', function(code, signal) {
+      debug('child exit: %s', signal || code);
+      assert.equal(code, 0);
+    });
+  });
 
   channel.request({cmd: 'clientRequest'}, function(message) {
-    console.log('server got', message);
+    debug('server got', message);
     assert(message.cmd === 'clientResponse');
     gotResponse++;
 
@@ -71,20 +95,19 @@ if (isParent) {
 
 } else {
   // Child
-  channel = WebsocketChannel.connect(onClientRequest,
-                                     onClientNotification,
-                                     ctlUri,
-                                     process.env.MESH_TOKEN);
+  debug('child connects to: %s', process.env.MESH_URI);
+  channel = WebsocketChannel.connect(onClientRequest, process.env.MESH_URI);
 
   function onClientRequest(message, callback) {
-    console.log('client got', message);
-    assert(message.cmd === 'clientRequest');
-    gotRequest++;
-    callback({cmd: 'clientResponse'});
-  }
+    debug('client got', message);
 
-  function onClientNotification(message) {
-    console.log('client got', message);
+    if (message.cmd === 'clientRequest') {
+      assert(message.cmd === 'clientRequest');
+      gotRequest++;
+      callback({cmd: 'clientResponse'});
+      return;
+    }
+
     assert(message.cmd === 'clientNotification');
     gotNotification++;
   }
@@ -92,7 +115,7 @@ if (isParent) {
   channel.notify({cmd: 'serverNotification'});
 
   channel.request({cmd: 'serverRequest'}, function(message) {
-    console.log('client got', message);
+    debug('client got', message);
     assert(message.cmd === 'serverResponse');
     gotResponse++;
   });

--- a/test/test-ws.js
+++ b/test/test-ws.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var assert = require('assert');
 var express = require('express');
 var expressWs = require('express-ws');


### PR DESCRIPTION
- remove onNotification: notifications are a send optimization
- router: allow token to be specified for a channel, its still
  auto-generated if not specified
- channel.connect: allow token to be specified in the URI - it can be
  provided as an argument, too, though I'm not sure that's useful

connected to strongloop-internal/scrum-nodeops#448

/cc @kraman I'll think you'll need the router change.