### PR TITLE
Don't unref TLS sockets on v0.10 (2)

### DIFF
--- a/lib/ws-channel.js
+++ b/lib/ws-channel.js
@@ -400,7 +400,9 @@ WebsocketChannel.prototype.getToken = function() {
 
 WebsocketChannel.prototype.unref = function() {
   this._unref = true;
-  if (this._socket && this._callbacksPending === 0)
+  // Note that on Node v0.10, TLS socket (CleartextStream) does not
+  // provide unref() method.
+  if (this._socket && this._callbacksPending === 0 && this._socket.unref)
     this._socket.unref();
 };
 
@@ -410,7 +412,9 @@ WebsocketChannel.prototype._onOpen = function() {
 
   this._socket = this._websocket._socket;
 
-  if (this._unref && this._callbacksPending === 0)
+  // Note that on Node v0.10, TLS socket (CleartextStream) does not
+  // provide unref() method.
+  if (this._unref && this._callbacksPending === 0 && this._socket.unref)
     this._socket.unref();
 };
 


### PR DESCRIPTION
This is a follow-up for 956c4010a1 that fixes more places where `unref()` is called. The problem was discovered by https://github.com/strongloop/apiconnect-collective-member/pull/94.

@sam-github I am going to land this without a review so that https://github.com/strongloop/apiconnect-collective-member/pull/94 can be finally landed. Let me know if you would like to make any improvements (extract shared method, add unit-tests, whatever), I can make them in a new PR.